### PR TITLE
Fix admin convoy loading

### DIFF
--- a/app/dashboard/admin/depot/[id]/hooks/useConvoys.ts
+++ b/app/dashboard/admin/depot/[id]/hooks/useConvoys.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { convoyService, authService } from "@/app/api/apiService";
+import { convoyService } from "@/service/convoyService";
+import { authService } from "@/service/authService";
 import { toast } from "@/components/ui/use-toast";
 import type { Convoy, ConvoyFormData, User } from "../types";
 

--- a/app/dashboard/admin/depot/[id]/hooks/useUsers.ts
+++ b/app/dashboard/admin/depot/[id]/hooks/useUsers.ts
@@ -1,8 +1,9 @@
 import { useState, useMemo, useEffect } from "react";
 import type { User, Convoy, UserFormData } from "../types";
-import type { UpdateUserRequest, RegisterRequest, UserRole } from "@/app/api/types";
+import type { UpdateUserRequest, RegisterRequest } from "@/types/auth.types";
+import type { UserRole } from "../types";
 import { toast } from "@/components/ui/use-toast";
-import { authService } from "@/app/api/apiService";
+import { authService } from "@/service/authService";
 
 interface UseUsersProps {
   initialUsers: User[];

--- a/app/dashboard/admin/depot/[id]/page.tsx
+++ b/app/dashboard/admin/depot/[id]/page.tsx
@@ -6,7 +6,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ArrowLeft, MapPin } from "lucide-react";
-import { busDepotService, authService } from "@/app/api/apiService";
+import { busDepotService } from "@/service/busDepotService";
+import { authService } from "@/service/authService";
 import { toast } from "@/components/ui/use-toast";
 
 import type { BusDepot, User, Convoy } from "./types";

--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -18,13 +18,13 @@ import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Bus, MapPin, Plus, Search } from "lucide-react"
 
-import { busDepotService } from "@/app/api/apiService"
-import type { BusDepot, CreateDepotRequest } from "@/app/api/types"
+import { busDepotService } from "@/service/busDepotService"
+import type { BusDepot, CreateBusDepotRequest } from "@/types/depot.types"
 
 export default function AdminDashboard() {
   const [busDepots, setBusDepots] = useState<BusDepot[]>([])
   const [isAddDepotDialogOpen, setIsAddDepotDialogOpen] = useState(false)
-  const [newDepotData, setNewDepotData] = useState<CreateDepotRequest>({ name: "", city: "", address: "" })
+  const [newDepotData, setNewDepotData] = useState<CreateBusDepotRequest>({ name: "", city: "", address: "" })
   const [searchQuery, setSearchQuery] = useState("")
   const [loading, setLoading] = useState(true)
 


### PR DESCRIPTION
## Summary
- use axios-based services in admin pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840292e48a883229b22b4936af9f297